### PR TITLE
Fix event listener trigger for non initialized piece

### DIFF
--- a/main.js
+++ b/main.js
@@ -36,7 +36,7 @@ moves = {
 };
 
 let board = new Board(ctx, ctxNext);
-addEventListener();
+
 initNext();
 
 function initNext() {
@@ -64,11 +64,11 @@ function addEventListener() {
           board.piece.move(p);
           p = moves[KEY.DOWN](board.piece);
         }
-        board.piece.hardDrop();     
+        board.piece.hardDrop();
       } else if (board.valid(p)) {
         board.piece.move(p);
         if (event.keyCode === KEY.DOWN) {
-          account.score += POINTS.SOFT_DROP;         
+          account.score += POINTS.SOFT_DROP;
         }
       }
     }
@@ -84,6 +84,7 @@ function resetGame() {
 }
 
 function play() {
+  addEventListener();
   resetGame();
   time.start = performance.now();
   // If we have an old game running a game then cancel the old
@@ -128,11 +129,10 @@ function pause() {
 
   cancelAnimationFrame(requestId);
   requestId = null;
-  
+
   ctx.fillStyle = 'black';
   ctx.fillRect(1, 3, 8, 1.2);
   ctx.font = '1px Arial';
   ctx.fillStyle = 'yellow';
   ctx.fillText('PAUSED', 3, 4);
 }
-


### PR DESCRIPTION
I try to rewrite your project to TypeScript in my [repo](https://github.com/MichalObi/js-tetris) and i have noticed a bug. When you press some buttons defined in KEY constant BEFORE you press play button you can see in console that code crashes - that's because no piece is yet visible on board `(board.piece is undefined)`.

To prevent this you can always check if piece is defined in `addEventListener` before generating new piece state, or you can add key event listener when user press play - as i do in this PR.
